### PR TITLE
chore(deps): Update Instana Agent Production to v2024.09.30.1118

### DIFF
--- a/instana/com.instana.agent.bootstrap.AgentBootstrap.cfg
+++ b/instana/com.instana.agent.bootstrap.AgentBootstrap.cfg
@@ -2,7 +2,7 @@
 # its value must be a valid tag from https://github.com/instana/agent-updates/tags
 # version = <tag>
 # renovate: datasource=github-tags depName=instana/agent-updates versioning=loose
-version = 2024.09.02.1507
+version = 2024.09.30.1118
 
 # This field controls which set of components is used by the agent at runtime.
 productName = ${env:INSTANA_PRODUCT_NAME}


### PR DESCRIPTION
Automated sync of instana/com.instana.agent.bootstrap.AgentBootstrap.cfg from branch "test" to "main".
Make sure that the test environment works as expected before approving and merging the change.
Merging will **trigger an production update including an agent restart**.

This update was driven by [this GitHub Action Workflow](https://github.com/instana/gitops-demo/blob/test/.github/workflows/sync-agent-version-to-main.yml).
Available Instana Agent tags can be found on the [instana/agent-updates](https://github.com/instana/agent-updates/tags) repository.
