### PR TITLE
INSTA-19263: Migrate Argo CD agent pinning from argocd-demo to gitops-demo repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ In the large majority of cases, you will likely need to version only files in th
 Only the files you version will override existing configurations present in the agent, so feel free to version the minimal amount of configurations you need.
 (At Instana we work really hard to ensure you need to configure anyhow as little as possible :-) .)
 
+### Directory Structure
+
+This repository contains the following key directories:
+
+- [instana/](./instana) - Contains host agent configuration files for Git-based Configuration Management capabilities
+- [kubernetes/instana/](./kubernetes/instana/) - Contains Kubernetes agent configuration with ArgoCD pinning
+  - [helm-chart](./kubernetes/instana/helm-chart/)- Helm chart configuration for Instana agent
+  - [instana-agent-operator](./kubernetes/instana/instana-agent-operator/) - Operator-based installation configuration for Instana agent
+
+For detailed information about Kubernetes agent version pinning with ArgoCD, see the [kubernetes/README.md](kubernetes/README.md).
+
 ## Git Hooks
 
 The [.githooks/post-receive](.githooks/post-receive) file provides you a sample of how to configure your Git repository so that, when a branch is updated, it will notify the Instana backend that some Git-enabled agents should update their configurations.

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,64 @@
+# Kubernetes Instana agent version pinning
+This guide demonstrates how to control Instana agent updates by pinning agent versions in Kubernetes environments using ArgoCD and environment variables. For more information, check the official documentation on [configuring updates](https://www.ibm.com/docs/en/instana-observability/current?topic=agents-configuring-updates-dynamic-host#version-pinning).
+
+## Pinning of the agent in operator and helm chart installation
+1. Verify `kubectx` points to the right cluster
+1. `kubectl` installed
+1. Verify ArgoCD is installed in the cluster
+    ```
+    kubectl get pods -n argocd
+    ```
+    If it's not installed, follow the instructions at https://argo-cd.readthedocs.io/en/stable/getting_started/.
+2. Construct the `instana-agent.customresource.yaml` for the operator installation, [example](instana/instana-agent-operator/dynamic-agent/instana-agent.customresource.yaml) or `values.yaml` for the helm-chart installation, [example](instana/helm-chart/dynamic-agent/values.yaml). The available environment variables for configuring the updates are `INSTANA_AGENT_UPDATES_TIME`, `INSTANA_AGENT_UPDATES_FREQUENCY`, and `INSTANA_AGENT_UPDATES_VERSION`. For the available agent, check https://github.com/instana/agent-updates/tags. See [Agent Configuration](https://www.ibm.com/docs/en/SSE1JP5_current/src/pages/setup_and_manage/host_agent/configuration/index.html#agent-configuration-file) documentation for more information about these settings.
+
+    Once you create the file with desired configuration, commit and push the changes to the remote repository.
+3. Ensure that the GitHub repo is either a public repository or that Argo CD has appropriate access to pull from it.
+Access can be configured using a GitHub access token or the SSH key authentication. First, create a secret in the cluster.
+    For the GitHub access token, run:
+    ```
+    kubectl create secret generic git-credentials --from-literal=username=<git-username> --from-literal=password=<git-token> -n argocd
+    ```
+    For the SSH key authentication, first generate the key. Once the SSH key is generated, determine the path of the private key (`~/.ssh/id_rsa` by default), and add the key to the Github repository settings. Then, create the `git-credentials` secret:
+    ```
+    kubectl create secret generic git-credentials \
+        --from-file=sshPrivateKey=<path-to-your-ssh-private-key> \
+        -n argocd
+    ```
+    Then, follow the steps to add the Git repo to ArgoCD:
+    ```
+    kubectl port-forward svc/argocd-server -n argocd 8080:443
+    ```
+    ```
+    argocd login localhost:8080
+    ```
+    When promted to enter the credentials for logging in, enter `admin` for the username. To get the password, run:
+    ```
+    kubectl get secret argocd-initial-admin-secret -n argocd -o jsonpath="{.data.password}" | base64 --decode
+    ```
+    Once logged in, add the GitHub repo with `argocd` command.
+    If you are using the GitHub access token, run:
+    ```
+    argocd repo add <github-repo-url> \
+     --username <git-username> --password <git-password>
+    ```
+    Alternatively, if you are using the SSH authentication, run:
+    ```
+    argocd repo add git@github.com:<your-org/your-repo>.git \
+     --ssh-private-key-path <private-key-path> \
+     --name <your-repo-name>
+    ```
+
+
+1. Create an Argo CD `Application` manifest that instructs ArgoCD to monitor and apply any changes from the GitHub repository to the cluster. For the example for the operator CR, please check the [operator example](instana/instana-agent-operator/argo/argo-application.yaml) and  for the helm chart installation, please chec the [values.yaml example](instana/helm-chart/argo/argo-application.yaml)).
+   * use `spec.target.revision` to specify which branch should be applied to the cluster. It's possible to have a branch per environment, e.g. `test`, `stage` and `prod`, so that each Instana agent version is tested out before using it in production.
+2. If running the operator installation, run the following command. Otherwise, skip this step.
+    Deploy the operator. For example, for the manual installation, run:
+    ```
+    kubectl apply -f https://github.com/instana/instana-agent-operator/releases/latest/download/instana-agent-operator.yaml
+    ```
+3. Apply the Argo CD `Application` manifest to the cluster. This is a manual one-time step.
+    ```
+    kubectl apply -f argo-application.yaml -n argocd
+
+    ```
+ 4. Verify that everything is configured properly by updating a pinned version in CR or values.yaml and pushing it to the remote repository. Argo CD should automatically detect changes and sync them to the cluster.

--- a/kubernetes/instana/helm-chart/argo/argo-application.yaml
+++ b/kubernetes/instana/helm-chart/argo/argo-application.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: instana-agent
+  namespace: argocd
+spec:
+  project: default
+  sources:
+    - repoURL: https://agents.instana.io/helm
+      chart: 'instana-agent'
+      targetRevision: '>=1.0.0'
+      helm:
+        valueFiles:
+        - $values/kubernetes/instana/helm-chart/dynamic-agent/values.yaml # full path to values.yaml
+    - repoURL: https://github.ibm.com/instana/gitops-demo.git # updated repo URL
+      targetRevision: "main" # the branch you'd like to apply to cluster
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: instana-agent # change if you have a custom instana-agent namespace
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/kubernetes/instana/helm-chart/dynamic-agent/values.yaml
+++ b/kubernetes/instana/helm-chart/dynamic-agent/values.yaml
@@ -1,0 +1,306 @@
+# name is the value which will be used as the base resource name for various resources associated with the agent.
+# name: instana-agent
+
+agent:
+  # agent.mode is used to set agent mode and it can be APM, INFRASTRUCTURE or AWS
+  # mode: APM
+
+  # agent.key is the secret token which your agent uses to authenticate to Instana's servers.
+  # key: null
+  # agent.downloadKey is key, sometimes known as "sales key", that allows you to download,
+  # software from Instana.
+  # downloadKey: null
+
+  # Rather than specifying the agent key and optionally the download key, you can "bring your
+  # own secret" creating it in the namespace in which you install the `instana-agent` and
+  # specify its name in the `keysSecret` field. The secret you create must contains
+  # a field called `key` and optionally one called `downloadKey`, which contain, respectively,
+  # the values you'd otherwise set in `.agent.key` and `agent.downloadKey`.
+  keysSecret: instana-agent-key
+
+  # agent.listenAddress is the IP address the agent HTTP server will listen to.
+  # listenAddress: "*"
+
+  # agent.endpointHost is the hostname of the Instana server your agents will connect to.
+  endpointHost: ingress-red-saas.instana.io
+  # agent.endpointPort is the port number (as a String) of the Instana server your agents will connect to.
+  endpointPort: 443
+
+  image:
+    # agent.image.name is the name of the container image of the Instana agent.
+    name: icr.io/instana/agent
+    # agent.image.digest is the digest (a.k.a. Image ID) of the agent container image; if specified, it has priority over agent.image.tag, which will be ignored.
+    #digest:
+    # agent.image.tag is the tag name of the agent container image; if agent.image.digest is specified, this property is ignored.
+    tag: latest
+    # agent.image.pullPolicy specifies when to pull the image container.
+    pullPolicy: Always
+    # agent.image.pullSecrets allows you to override the default pull secret that is created when agent.image.name starts with "containers.instana.io"
+    # Setting agent.image.pullSecrets prevents the creation of the default "containers-instana-io" secret.
+    # pullSecrets:
+    #   - name: my_awesome_secret_instead
+    # If you want no imagePullSecrets to be specified in the agent pod, you can just pass an empty array to agent.image.pullSecrets
+    # pullSecrets: []
+
+  # The minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available
+  minReadySeconds: 0
+
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+
+  pod:
+    # agent.pod.annotations are additional annotations to be added to the agent pods.
+    annotations: {}
+
+    # agent.pod.labels are additional labels to be added to the agent pods.
+    labels: {}
+
+    # agent.pod.tolerations are tolerations to influence agent pod assignment.
+    #   https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    tolerations: []
+
+    # agent.pod.affinity are affinities to influence agent pod assignment.
+    # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    affinity: {}
+
+    # agent.pod.priorityClassName is the name of an existing PriorityClass that should be set on the agent pods
+    #   https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+    priorityClassName: null
+
+    # agent.pod.requests and agent.pod.limits adjusts the resource assignments for the DaemonSet agent
+    #   regardless of the kubernetes.deployment.enabled setting
+    requests:
+      # agent.pod.requests.memory is the requested memory allocation in MiB for the agent pods.
+      memory: 768Mi
+      # agent.pod.requests.cpu are the requested CPU units allocation for the agent pods.
+      cpu: 0.5
+    limits:
+      # agent.pod.limits.memory set the memory allocation limits in MiB for the agent pods.
+      memory: 768Mi
+      # agent.pod.limits.cpu sets the CPU units allocation limits for the agent pods.
+      cpu: 1.5
+
+  # agent.proxyHost sets the INSTANA_AGENT_PROXY_HOST environment variable.
+  # proxyHost: null
+  # agent.proxyPort sets the INSTANA_AGENT_PROXY_PORT environment variable.
+  # proxyPort: 80
+  # agent.proxyProtocol sets the INSTANA_AGENT_PROXY_PROTOCOL environment variable.
+  # proxyProtocol: HTTP
+  # agent.proxyUser sets the INSTANA_AGENT_PROXY_USER environment variable.
+  # proxyUser: null
+  # agent.proxyPassword sets the INSTANA_AGENT_PROXY_PASSWORD environment variable.
+  # proxyPassword: null
+  # agent.proxyUseDNS sets the INSTANA_AGENT_PROXY_USE_DNS environment variable.
+  # proxyUseDNS: false
+
+  # use this to set additional environment variables for the instana agent
+  # for example:
+  env:
+    INSTANA_AGENT_UPDATES_VERSION: 2024.10.28.1344 # check for available versions at https://github.com/instana/agent-updates/tags 
+    # INSTANA_AGENT_UPDATES_TIME: 4:30 # no effect when version is pinned with INSTANA_AGENT_UPDATES_VERSION
+    # INSTANA_AGENT_UPDATES_FREQUENCY: DAY # no effect when version is pinned with INSTANA_AGENT_UPDATES_VERSION
+    
+
+  configuration:
+    # When setting this to true, the Helm chart will automatically look up the entries
+    # of the default instana-agent ConfigMap, and mount as agent configuration files
+    # under /opt/instana/agent/etc/instana all entries with keys that match the
+    # 'configuration-*.yaml' scheme
+    #
+    # IMPORTANT: Needs Helm 3.1+ as it is built on the `lookup` function
+    # IMPORTANT: Editing the ConfigMap adding keys requires a `helm upgrade` to take effect
+    autoMountConfigEntries: false
+
+    # When setting this to true, the updates of the default instana-agent ConfigMap
+    # will be reflected in the pod without requiring a pod restart
+    hotreloadEnabled: false
+
+  configuration_yaml: |
+    # Manual a-priori configuration. Configuration will be only used when the sensor
+    # is actually installed by the agent.
+    # The commented out example values represent example configuration and are not
+    # necessarily defaults. Defaults are usually 'absent' or mentioned separately.
+    # Changes are hot reloaded unless otherwise mentioned.
+
+    # It is possible to create files called 'configuration-abc.yaml' which are
+    # merged with this file in file system order. So 'configuration-cde.yaml' comes
+    # after 'configuration-abc.yaml'. Only nested structures are merged, values are
+    # overwritten by subsequent configurations.
+
+    # Secrets
+    # To filter sensitive data from collection by the agent, all sensors respect
+    # the following secrets configuration. If a key collected by a sensor matches
+    # an entry from the list, the value is redacted.
+    #com.instana.secrets:
+    #  matcher: 'contains-ignore-case' # 'contains-ignore-case', 'contains', 'regex'
+    #  list:
+    #    - 'key'
+    #    - 'password'
+    #    - 'secret'
+
+    # Host
+    #com.instana.plugin.host:
+    #  tags:
+    #    - 'dev'
+    #    - 'app1'
+
+    # Hardware & Zone
+    #com.instana.plugin.generic.hardware:
+    #  enabled: true # disabled by default
+    #  availability-zone: 'zone'
+
+  # agent.redactKubernetesSecrets sets the INSTANA_KUBERNETES_REDACT_SECRETS environment variable.
+  # redactKubernetesSecrets: null
+
+  # agent.host.repository sets a host path to be mounted as the agent maven repository (for debugging or development purposes)
+  host:
+    repository: null
+
+  # agent.serviceMesh.enabled sets the ENABLE_AGENT_SOCKET environment variable.
+  serviceMesh:
+    enabled: true
+
+cluster:
+  # cluster.name represents the name that will be assigned to this cluster in Instana
+  name: my-dev-cluster
+
+leaderElector:
+  image:
+    # leaderElector.image.name is the name of the container image of the leader elector.
+    name: icr.io/instana/leader-elector
+    # leaderElector.image.digest is the digest (a.k.a. Image ID) of the leader elector container image; if specified, it has priority over leaderElector.image.digest, which will be ignored.
+    #digest:
+    # leaderElector.image.tag is the tag name of the agent container image; if leaderElector.image.digest is specified, this property is ignored.
+    tag: 0.5.19
+  port: 42655
+
+# openshift specifies whether the cluster role should include openshift permissions and other tweaks to the YAML.
+# The chart will try to auto-detect if the cluster is OpenShift, so you will likely not even need to set this explicitly.
+# openshift: true
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+service:
+  # Specifies whether to create the instana-agent service to expose within the cluster the Prometheus remote-write, OpenTelemetry GRCP endpoint and other APIs
+  # Note: Requires Kubernetes 1.17+, as it uses topologyKeys
+  create: true
+
+opentelemetry:
+#  enabled: false # legacy setting, will only enable grpc, defaults to false
+  grpc:
+    enabled: true # takes precedence over legacy settings above, defaults to true if "grpc:" is present
+  http:
+    enabled: true # allows to enable http endpoints, defaults to true if "http:" is present
+
+prometheus:
+  remoteWrite:
+    enabled: false # If true, it will also apply `service.create=true`
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and `create` is true, a name is generated using the fullname template
+  # name: instana-agent
+  # Annotations to add to the service account
+  annotations: {}
+
+podSecurityPolicy:
+  # Specifies whether a PodSecurityPolicy should be authorized for the Instana Agent pods.
+  # Requires `rbac.create` to be `true` as well and K8s version below v1.25.
+  enable: false
+  # The name of an existing PodSecurityPolicy you would like to authorize for the Instana Agent pods.
+  # If not set and `enable` is true, a PodSecurityPolicy will be created with a name generated using the fullname template.
+  name: null
+
+zone:
+  # zone.name is the custom zone that detected technologies will be assigned to
+  name: null
+
+k8s_sensor:
+  image:
+    # k8s_sensor.image.name is the name of the container image of the Instana agent.
+    name: icr.io/instana/k8sensor
+    # k8s_sensor.image.digest is the digest (a.k.a. Image ID) of the agent container image; if specified, it has priority over agent.image.tag, which will be ignored.
+    #digest:
+    # k8s_sensor.image.tag is the tag name of the agent container image; if agent.image.digest is specified, this property is ignored.
+    tag: latest
+    # k8s_sensor.image.pullPolicy specifies when to pull the image container.
+    pullPolicy: Always
+  deployment:
+    # Specifies whether or not to enable the Deployment and turn off the Kubernetes sensor in the DaemonSet
+    enabled: true
+    # Use three replicas to ensure the HA by the default.
+    replicas: 3
+    # k8s_sensor.deployment.pod adjusts the resource assignments for the agent independently of the DaemonSet agent when k8s_sensor.deployment.enabled=true
+    pod:
+      requests:
+        # k8s_sensor.deployment.pod.requests.memory is the requested memory allocation in MiB for the agent pods.
+        memory: 128Mi
+        # k8s_sensor.deployment.pod.requests.cpu are the requested CPU units allocation for the agent pods.
+        cpu: 120m
+      limits:
+        # k8s_sensor.deployment.pod.limits.memory set the memory allocation limits in MiB for the agent pods.
+        memory: 2048Mi
+        # k8s_sensor.deployment.pod.limits.cpu sets the CPU units allocation limits for the agent pods.
+        cpu: 500m
+      affinity:
+        podAntiAffinity:
+          # Soft anti-affinity policy: try not to schedule multiple kubernetes-sensor pods on the same node.
+          # If the policy is set to "requiredDuringSchedulingIgnoredDuringExecution", if the cluster has
+          # fewer nodes than the amount of desired replicas, `helm install/upgrade --wait` will not return.
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: instana/agent-mode
+                  operator: In
+                  values: [ KUBERNETES ]
+              topologyKey: "kubernetes.io/hostname"
+    # The minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available
+    minReadySeconds: 0
+  podDisruptionBudget:
+    # Specifies whether or not to setup a pod disruption budget for the k8sensor deployment
+    enabled: false
+
+kubernetes:
+  # Configures use of a Deployment for the Kubernetes sensor rather than as a potential member of the DaemonSet. Is only accepted if k8s_sensor.deployment.enabled=false
+  deployment:
+    # Specifies whether or not to enable the Deployment and turn off the Kubernetes sensor in the DaemonSet
+    enabled: false
+    # Use a single replica, the impact will generally be low and we need to address a host of other concerns where clusters are large.
+    replicas: 1
+    # The minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available
+    minReadySeconds: 0
+    # kubernetes.deployment.pod adjusts the resource assignments for the agent independently of the DaemonSet agent when kubernetes.deployment.enabled=true
+    pod:
+      requests:
+        # kubernetes.deployment.pod.requests.memory is the requested memory allocation in MiB for the agent pods.
+        memory: 1024Mi
+        # kubernetes.deployment.pod.requests.cpu are the requested CPU units allocation for the agent pods.
+        cpu: 720m
+      limits:
+        # kubernetes.deployment.pod.limits.memory set the memory allocation limits in MiB for the agent pods.
+        memory: 3072Mi
+        # kubernetes.deployment.pod.limits.cpu sets the CPU units allocation limits for the agent pods.
+        cpu: 4
+
+# zones:
+#  # Configure use of zones to use tolerations as the basis to associate a specific daemonset per tainted node pool
+#  - name: pool-01
+#    tolerations:
+#    - key: "pool"
+#      operator: "Equal"
+#      value: "pool-01"
+#      effect: "NoExecute"
+#  - name: pool-02
+#    tolerations:
+#    - key: "pool"
+#      operator: "Equal"
+#      value: "pool-02"
+#      effect: "NoExecute"

--- a/kubernetes/instana/instana-agent-key.yaml
+++ b/kubernetes/instana/instana-agent-key.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: instana-agent-key
+data:
+  key: <encoded-agent-key>

--- a/kubernetes/instana/instana-agent-operator/argo/argo-application.yaml
+++ b/kubernetes/instana/instana-agent-operator/argo/argo-application.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: instana-agent-operator-app
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.ibm.com/instana/gitops-demo # updated repo URL
+    targetRevision: main # the branch you'd like to apply to cluster 
+    path: 'kubernetes/instana/instana-agent-operator/dynamic-agent' # updated path to the file in the repo
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: instana-agent
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/kubernetes/instana/instana-agent-operator/dynamic-agent/instana-agent.customresource.yaml
+++ b/kubernetes/instana/instana-agent-operator/dynamic-agent/instana-agent.customresource.yaml
@@ -1,0 +1,16 @@
+apiVersion: instana.io/v1
+kind: InstanaAgent
+metadata:
+  name: instana-agent
+  namespace: instana-agent
+spec:
+  cluster:
+   name: my-dev-cluster
+  agent:
+   keysSecret: instana-agent-key
+   endpointHost: ingress-red-saas.instana.io
+   endpointPort: "443"
+   env:
+    INSTANA_AGENT_UPDATES_VERSION: 2024.10.28.1344 # check for available versions at https://github.com/instana/agent-updates/tags 
+    # INSTANA_AGENT_UPDATES_TIME: 4:30 # no effect when version is pinned with INSTANA_AGENT_UPDATES_VERSION
+    # INSTANA_AGENT_UPDATES_FREQUENCY: DAY # no effect when version is pinned with INSTANA_AGENT_UPDATES_VERSION


### PR DESCRIPTION
## Description
This PR migrates the Argo CD pinning configuration for Instana agents from the [argocd-demo](https://github.com/instana/argocd-demo) repository to the gitops-demo repository. The configuration is now located under the `kubernetes/instana` directory.

## Changes
- Added Kubernetes agent configuration files under `kubernetes/instana/`
- Added helm chart configuration for Instana agent
- Added operator-based installation configuration
- Added documentation for Kubernetes agent version pinning with ArgoCD
- Updated main README.md to include information about the new directory structure

REF: [INSTA-19263](https://jsw.ibm.com/browse/INSTA-19263)